### PR TITLE
Allow YouTube restricted videos to be embeddable

### DIFF
--- a/youTune/VideoViewController.swift
+++ b/youTune/VideoViewController.swift
@@ -20,15 +20,24 @@ class VideoViewController: UIViewController {
         super.viewDidLoad()
         getVideo(videoId: videoId)
         self.videoDescription.text = descriptionVideo
+        self.webView.navigationDelegate = self
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
     
-    func getVideo(videoId: String){
-        let url = URL(string: "http://youtube.com/embed/\(videoId)")
-        webView.load(URLRequest(url: url!))
+    func getVideo(videoId: String) {
+        let html = "<a id=\"video\" href=\"https://www.youtube.com/embed/\(videoId)\"></a>"
+        webView.loadHTMLString(html, baseURL: URL(string: "https://www.youtube.com"))
+        webView.isOpaque = false
+        webView.backgroundColor = UIColor.black
     }
+}
 
+extension VideoViewController: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        let js = "document.getElementById('video').click();"
+        webView.evaluateJavaScript(js, completionHandler: nil)
+    }
 }


### PR DESCRIPTION
Plutôt que d'utiliser la méthode `webView.load()` qui bloque par défaut les vidéos YouTube avec du contenu copyright, je simule une page web avec un lien dedans en HTML que je charge avec `webView.loadHTMLString()` puis un petit javascript clique sur le lien dès que la page est chargée ce qui lance le player, sans la restriction 😄 